### PR TITLE
feat: add optional custom error messages to schema validators

### DIFF
--- a/src/validation/array.test.ts
+++ b/src/validation/array.test.ts
@@ -66,3 +66,28 @@ test("Validate Array Length", () => {
     "Error at ``: Must have at most 3 items.",
   );
 });
+
+test("Validate Array Min Custom Message", () => {
+  const schema = string().array().min(1, "Need at least one");
+  expect(schema.parse(["hello"])).toStrictEqual(["hello"]);
+  expect(() => schema.parse([])).toThrow("Error at ``: Need at least one.");
+});
+
+test("Validate Array Max Custom Message", () => {
+  const schema = string().array().max(2, "Too many items");
+  expect(schema.parse(["a", "b"])).toStrictEqual(["a", "b"]);
+  expect(() => schema.parse(["a", "b", "c"])).toThrow(
+    "Error at ``: Too many items.",
+  );
+});
+
+test("Validate Array Length Custom Message", () => {
+  const schema = string().array().length(2, "Must be exactly two");
+  expect(schema.parse(["a", "b"])).toStrictEqual(["a", "b"]);
+  expect(() => schema.parse(["a"])).toThrow(
+    "Error at ``: Must be exactly two.",
+  );
+  expect(() => schema.parse(["a", "b", "c"])).toThrow(
+    "Error at ``: Must be exactly two.",
+  );
+});

--- a/src/validation/integer.test.ts
+++ b/src/validation/integer.test.ts
@@ -43,3 +43,15 @@ test("Validate Integer Max", () => {
     "Error at ``: Must be at most 100, but was 101.",
   );
 });
+
+test("Validate Integer Min Custom Message", () => {
+  const schema = integer().min(10, "Too small");
+  expect(schema.parse(10)).toStrictEqual(10);
+  expect(() => schema.parse(9)).toThrow("Error at ``: Too small.");
+});
+
+test("Validate Integer Max Custom Message", () => {
+  const schema = integer().max(100, "Too large");
+  expect(schema.parse(100)).toStrictEqual(100);
+  expect(() => schema.parse(101)).toThrow("Error at ``: Too large.");
+});

--- a/src/validation/integer.ts
+++ b/src/validation/integer.ts
@@ -4,33 +4,42 @@ import { ModifiableSchema } from "./modifiable.js";
 class IntegerSchema extends ModifiableSchema<number> {
   private readonly minValue?: number;
   private readonly maxValue?: number;
+  private readonly minMessage?: string;
+  private readonly maxMessage?: string;
 
-  public constructor(min?: number, max?: number) {
+  public constructor(
+    min?: number,
+    max?: number,
+    minMsg?: string,
+    maxMsg?: string,
+  ) {
     super();
     this.minValue = min;
     this.maxValue = max;
+    this.minMessage = minMsg;
+    this.maxMessage = maxMsg;
   }
 
   /**
    * Set the minimum value the number is allowed to be.
    * @param value - The minimum value.
    */
-  public min(value: number): IntegerSchema {
+  public min(value: number, message?: string): IntegerSchema {
     if (!Number.isInteger(value)) {
       throw new Error("minimum value has to be an integer");
     }
-    return new IntegerSchema(value, this.maxValue);
+    return new IntegerSchema(value, this.maxValue, message, this.maxMessage);
   }
 
   /**
    * Set the maximum value the number is allowed to be.
    * @param value - The maximum value.
    */
-  public max(value: number): IntegerSchema {
+  public max(value: number, message?: string): IntegerSchema {
     if (!Number.isInteger(value)) {
       throw new Error("maximum value has to be an integer");
     }
-    return new IntegerSchema(this.minValue, value);
+    return new IntegerSchema(this.minValue, value, this.minMessage, message);
   }
 
   public override parse(obj: unknown): number {
@@ -47,12 +56,20 @@ class IntegerSchema extends ModifiableSchema<number> {
     }
     if (this.minValue !== undefined && num < this.minValue) {
       throw new ValidationError([
-        new Issue([], `Must be at least ${this.minValue}, but was ${num}`),
+        new Issue(
+          [],
+          this.minMessage ??
+            `Must be at least ${this.minValue}, but was ${num}`,
+        ),
       ]);
     }
     if (this.maxValue !== undefined && num > this.maxValue) {
       throw new ValidationError([
-        new Issue([], `Must be at most ${this.maxValue}, but was ${num}`),
+        new Issue(
+          [],
+          this.maxMessage ??
+            `Must be at most ${this.maxValue}, but was ${num}`,
+        ),
       ]);
     }
     return num;

--- a/src/validation/modifiable.test.ts
+++ b/src/validation/modifiable.test.ts
@@ -103,3 +103,22 @@ test("Validate Refine Double", () => {
     "Error at ``: Must be less than 100.",
   );
 });
+
+test("Validate Refined String Min Custom Message", () => {
+  const schema = string().pattern(/^[a-z]+$/).min(2, "Too short");
+  expect(schema.parse("ab")).toStrictEqual("ab");
+  expect(() => schema.parse("a")).toThrow("Error at ``: Too short.");
+});
+
+test("Validate Refined String Max Custom Message", () => {
+  const schema = string().pattern(/^[a-z]+$/).max(3, "Too long");
+  expect(schema.parse("abc")).toStrictEqual("abc");
+  expect(() => schema.parse("abcd")).toThrow("Error at ``: Too long.");
+});
+
+test("Validate Refined String Length Custom Message", () => {
+  const schema = string().pattern(/^[a-z]+$/).length(3, "Must be 3 chars");
+  expect(schema.parse("abc")).toStrictEqual("abc");
+  expect(() => schema.parse("ab")).toThrow("Error at ``: Must be 3 chars.");
+  expect(() => schema.parse("abcd")).toThrow("Error at ``: Must be 3 chars.");
+});

--- a/src/validation/modifiable.ts
+++ b/src/validation/modifiable.ts
@@ -143,7 +143,7 @@ export class RefinedSchema<T> extends ModifiableSchema<T> {
    * Set the minimum length/items for strings and arrays.
    * @param value - The minimum constraint.
    */
-  public min(value: number): RefinedSchema<T> {
+  public min(value: number, message?: string): RefinedSchema<T> {
     const docs = this.documentation() as Record<string, unknown>;
     const isArray = docs.type === "array";
     return this.refine(
@@ -151,9 +151,10 @@ export class RefinedSchema<T> extends ModifiableSchema<T> {
         const len = (v as string | unknown[]).length;
         return (
           len >= value ||
-          (isArray
-            ? `Must have at least ${value} items`
-            : `Must be at least ${value} characters`)
+          (message ??
+            (isArray
+              ? `Must have at least ${value} items`
+              : `Must be at least ${value} characters`))
         );
       }) as (value: T) => boolean | string,
       isArray ? { minItems: value } : { minLength: value },
@@ -164,7 +165,7 @@ export class RefinedSchema<T> extends ModifiableSchema<T> {
    * Set the maximum length/items for strings and arrays.
    * @param value - The maximum constraint.
    */
-  public max(value: number): RefinedSchema<T> {
+  public max(value: number, message?: string): RefinedSchema<T> {
     const docs = this.documentation() as Record<string, unknown>;
     const isArray = docs.type === "array";
     return this.refine(
@@ -172,9 +173,10 @@ export class RefinedSchema<T> extends ModifiableSchema<T> {
         const len = (v as string | unknown[]).length;
         return (
           len <= value ||
-          (isArray
-            ? `Must have at most ${value} items`
-            : `Must be at most ${value} characters`)
+          (message ??
+            (isArray
+              ? `Must have at most ${value} items`
+              : `Must be at most ${value} characters`))
         );
       }) as (value: T) => boolean | string,
       isArray ? { maxItems: value } : { maxLength: value },
@@ -185,8 +187,8 @@ export class RefinedSchema<T> extends ModifiableSchema<T> {
    * Set the exact length/items for strings and arrays.
    * @param value - The exact constraint.
    */
-  public length(value: number): RefinedSchema<T> {
-    return this.min(value).max(value);
+  public length(value: number, message?: string): RefinedSchema<T> {
+    return this.min(value, message).max(value, message);
   }
 
   public override parse(obj: unknown): T {
@@ -225,9 +227,11 @@ export class ArraySchema<
    * Set the minimum number of items for arrays.
    * @param items - The minimum number of items.
    */
-  public min(items: number): RefinedSchema<Typeof<ItemSchema>[]> {
+  public min(items: number, message?: string): RefinedSchema<Typeof<ItemSchema>[]> {
     return this.refine(
-      (arr) => arr.length >= items || `Must have at least ${items} items`,
+      (arr) =>
+        arr.length >= items ||
+        (message ?? `Must have at least ${items} items`),
       { minItems: items },
     );
   }
@@ -236,9 +240,11 @@ export class ArraySchema<
    * Set the maximum number of items for arrays.
    * @param items - The maximum number of items.
    */
-  public max(items: number): RefinedSchema<Typeof<ItemSchema>[]> {
+  public max(items: number, message?: string): RefinedSchema<Typeof<ItemSchema>[]> {
     return this.refine(
-      (arr) => arr.length <= items || `Must have at most ${items} items`,
+      (arr) =>
+        arr.length <= items ||
+        (message ?? `Must have at most ${items} items`),
       { maxItems: items },
     );
   }
@@ -248,9 +254,11 @@ export class ArraySchema<
    * This is equivalent to calling both min and max.
    * @param items - The number of items.
    */
-  public length(items: number): RefinedSchema<Typeof<ItemSchema>[]> {
-    return this.min(items).refine(
-      (arr) => arr.length <= items || `Must have at most ${items} items`,
+  public length(items: number, message?: string): RefinedSchema<Typeof<ItemSchema>[]> {
+    return this.min(items, message).refine(
+      (arr) =>
+        arr.length <= items ||
+        (message ?? `Must have at most ${items} items`),
       { maxItems: items },
     );
   }

--- a/src/validation/number.test.ts
+++ b/src/validation/number.test.ts
@@ -37,3 +37,15 @@ test("Validate Number Max", () => {
     "Error at ``: Must be at most 100, but was 101.",
   );
 });
+
+test("Validate Number Min Custom Message", () => {
+  const schema = number().min(10, "Too small");
+  expect(schema.parse(10)).toStrictEqual(10);
+  expect(() => schema.parse(9)).toThrow("Error at ``: Too small.");
+});
+
+test("Validate Number Max Custom Message", () => {
+  const schema = number().max(100, "Too large");
+  expect(schema.parse(100)).toStrictEqual(100);
+  expect(() => schema.parse(101)).toThrow("Error at ``: Too large.");
+});

--- a/src/validation/number.ts
+++ b/src/validation/number.ts
@@ -4,27 +4,36 @@ import { ModifiableSchema } from "./modifiable.js";
 class NumberSchema extends ModifiableSchema<number> {
   private readonly minValue?: number;
   private readonly maxValue?: number;
+  private readonly minMessage?: string;
+  private readonly maxMessage?: string;
 
-  public constructor(min?: number, max?: number) {
+  public constructor(
+    min?: number,
+    max?: number,
+    minMsg?: string,
+    maxMsg?: string,
+  ) {
     super();
     this.minValue = min;
     this.maxValue = max;
+    this.minMessage = minMsg;
+    this.maxMessage = maxMsg;
   }
 
   /**
    * Set the minimum value the number is allowed to be.
    * @param value - The minimum value.
    */
-  public min(value: number): NumberSchema {
-    return new NumberSchema(value, this.maxValue);
+  public min(value: number, message?: string): NumberSchema {
+    return new NumberSchema(value, this.maxValue, message, this.maxMessage);
   }
 
   /**
    * Set the maximum value the number is allowed to be.
    * @param value - The maximum value.
    */
-  public max(value: number): NumberSchema {
-    return new NumberSchema(this.minValue, value);
+  public max(value: number, message?: string): NumberSchema {
+    return new NumberSchema(this.minValue, value, this.minMessage, message);
   }
 
   public override parse(obj: unknown): number {
@@ -41,12 +50,20 @@ class NumberSchema extends ModifiableSchema<number> {
     }
     if (this.minValue !== undefined && num < this.minValue) {
       throw new ValidationError([
-        new Issue([], `Must be at least ${this.minValue}, but was ${num}`),
+        new Issue(
+          [],
+          this.minMessage ??
+            `Must be at least ${this.minValue}, but was ${num}`,
+        ),
       ]);
     }
     if (this.maxValue !== undefined && num > this.maxValue) {
       throw new ValidationError([
-        new Issue([], `Must be at most ${this.maxValue}, but was ${num}`),
+        new Issue(
+          [],
+          this.maxMessage ??
+            `Must be at most ${this.maxValue}, but was ${num}`,
+        ),
       ]);
     }
     return num;

--- a/src/validation/string.test.ts
+++ b/src/validation/string.test.ts
@@ -144,3 +144,29 @@ test("Validate String Pattern Then Refine Min", () => {
     "Error at ``: Must be at least 2 characters.",
   );
 });
+
+test("Validate String Min Custom Message", () => {
+  const schema = string().min(2, "Too short");
+  expect(schema.parse("ab")).toStrictEqual("ab");
+  expect(() => schema.parse("a")).toThrow("Error at ``: Too short.");
+});
+
+test("Validate String Max Custom Message", () => {
+  const schema = string().max(3, "Too long");
+  expect(schema.parse("abc")).toStrictEqual("abc");
+  expect(() => schema.parse("abcd")).toThrow("Error at ``: Too long.");
+});
+
+test("Validate String Email Custom Message", () => {
+  const schema = string().email("Invalid email");
+  expect(schema.parse("user@example.com")).toStrictEqual("user@example.com");
+  expect(() => schema.parse("not-email")).toThrow(
+    "Error at ``: Invalid email.",
+  );
+});
+
+test("Validate String Pattern Custom Message", () => {
+  const schema = string().pattern(/^[0-9]+$/, "Numbers only");
+  expect(schema.parse("123")).toStrictEqual("123");
+  expect(() => schema.parse("abc")).toThrow("Error at ``: Numbers only.");
+});

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -8,9 +8,11 @@ class StringSchema extends ModifiableSchema<string> {
    * Set the minimum length the string is allowed to be.
    * @param length - The minimum length.
    */
-  public min(length: number) {
+  public min(length: number, message?: string) {
     return this.refine(
-      (s) => s.length >= length || `Must be at least ${length} characters`,
+      (s) =>
+        s.length >= length ||
+        (message ?? `Must be at least ${length} characters`),
       { minLength: length },
     );
   }
@@ -19,9 +21,11 @@ class StringSchema extends ModifiableSchema<string> {
    * Set the maximum length the string is allowed to be.
    * @param length - The maximum length.
    */
-  public max(length: number) {
+  public max(length: number, message?: string) {
     return this.refine(
-      (s) => s.length <= length || `Must be at most ${length} characters`,
+      (s) =>
+        s.length <= length ||
+        (message ?? `Must be at most ${length} characters`),
       { maxLength: length },
     );
   }
@@ -29,19 +33,22 @@ class StringSchema extends ModifiableSchema<string> {
   /**
    * Require the string to be a valid email address.
    */
-  public email() {
-    return this.refine((s) => EMAIL_REGEX.test(s) || "Expected email address", {
-      format: "email",
-    });
+  public email(message?: string) {
+    return this.refine(
+      (s) => EMAIL_REGEX.test(s) || (message ?? "Expected email address"),
+      { format: "email" },
+    );
   }
 
   /**
    * Require the string to match the specified pattern.
    * @param pattern - A regular expression.
    */
-  public pattern(pattern: RegExp) {
+  public pattern(pattern: RegExp, message?: string) {
     return this.refine(
-      (s) => pattern.test(s) || `Does not match pattern /${pattern.source}/`,
+      (s) =>
+        pattern.test(s) ||
+        (message ?? `Does not match pattern /${pattern.source}/`),
       { pattern: pattern.source },
     );
   }


### PR DESCRIPTION
Add an optional `message` parameter to all constraint methods (min, max, email, pattern, length) so users can provide custom error messages for i18n and UX purposes. Default messages are preserved when no custom message is provided.